### PR TITLE
[ADD] l10n_ar_afipws: update partner data from AFIP A5 census (BETA)

### DIFF
--- a/l10n_ar_afipws/__manifest__.py
+++ b/l10n_ar_afipws/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Modulo Base para los Web Services de AFIP',
-    'version': '13.0.1.0.0',
+    'version': '13.0.1.1.0',
     'category': 'Localization/Argentina',
     'sequence': 14,
     'author': 'ADHOC SA, Moldeo Interactive,Odoo Community Association (OCA)',
@@ -15,6 +15,7 @@
     },
     'data': [
         'wizard/upload_certificate_view.xml',
+        'wizard/res_partner_update_from_padron_wizard_view.xml',
         'views/afipws_menuitem.xml',
         'views/afipws_certificate_view.xml',
         'views/afipws_certificate_alias_view.xml',

--- a/l10n_ar_afipws/models/__init__.py
+++ b/l10n_ar_afipws/models/__init__.py
@@ -7,3 +7,4 @@ from . import afipws_certificate
 from . import afipws_connection
 from . import res_company
 from . import res_config_settings
+from . import res_partner

--- a/l10n_ar_afipws/models/res_partner.py
+++ b/l10n_ar_afipws/models/res_partner.py
@@ -1,0 +1,134 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+
+from odoo import fields, models, api, _
+from odoo.exceptions import UserError
+try:
+    from pysimplesoap.client import SoapFault
+except ImportError:
+    SoapFault = None
+import logging
+_logger = logging.getLogger(__name__)
+
+
+class ResPartner(models.Model):
+    _inherit = 'res.partner'
+
+    def cuit_required(self):
+        self.ensure_one()
+        if not self.vat:
+            raise UserError(_('No CUIT configured for partner [%i] %s') % (
+                self.id, self.name))
+        return self.vat
+
+    def get_data_from_padron_afip(self):
+        self.ensure_one()
+        cuit = self.cuit_required()
+
+        # GET COMPANY
+        # if there is certificate for user company, use that one, if not
+        # use the company for the first certificate found
+        company = self.env.user.company_id
+        env_type = company._get_environment_type()
+        try:
+            certificate = company.get_key_and_certificate(
+                company._get_environment_type())
+        except Exception:
+            certificate = self.env['afipws.certificate'].search([
+                ('alias_id.type', '=', env_type),
+                ('state', '=', 'confirmed'),
+            ], limit=1)
+            if not certificate:
+                raise UserError(_(
+                    'Not confirmed certificate found on database'))
+            company = certificate.alias_id.company_id
+
+        # consultamos a5 ya que extiende a4 y tiene validez de constancia
+        padron = company.get_connection('ws_sr_padron_a5').connect()
+        error_msg = _(
+            'No pudimos actualizar desde padron afip al partner %s (%s).\n'
+            'Recomendamos verificar manualmente en la página de AFIP.\n'
+            'Obtuvimos este error: %s')
+        try:
+            padron.Consultar(cuit)
+        except SoapFault as e:
+            raise UserError(error_msg % (self.name, cuit, e.faultstring))
+        except Exception as e:
+            raise UserError(error_msg % (self.name, cuit, e))
+
+        if not padron.denominacion or padron.denominacion == ', ':
+            raise UserError(error_msg % (
+                self.name, cuit, 'La afip no devolvió nombre'))
+
+        # porque imp_iva activo puede ser S o AC
+        imp_iva = padron.imp_iva
+        if imp_iva == 'S':
+            imp_iva = 'AC'
+        elif imp_iva == 'N':
+            # por ej. monotributista devuelve N
+            imp_iva = 'NI'
+        
+        vals = {
+            'name': padron.denominacion,
+            'estado_padron': padron.estado,
+            'street': padron.direccion,
+            'city': padron.localidad,
+            'zip': padron.cod_postal,
+            'actividades_padron': self.actividades_padron.search(
+                [('code', 'in', padron.actividades)]).ids,
+            'impuestos_padron': self.impuestos_padron.search(
+                [('code', 'in', padron.impuestos)]).ids,
+            'imp_iva_padron': imp_iva,
+            'monotributo_padron': padron.monotributo,
+            'actividad_monotributo_padron': padron.actividad_monotributo,
+            'empleador_padron': padron.empleador == 'S' and True,
+            'integrante_soc_padron': padron.integrante_soc,
+            'last_update_padron': fields.Date.today(),
+        }
+        ganancias_inscripto = [10, 11]
+        ganancias_exento = [12]
+        if set(ganancias_inscripto) & set(padron.impuestos):
+            vals['imp_ganancias_padron'] = 'AC'
+        elif set(ganancias_exento) & set(padron.impuestos):
+            vals['imp_ganancias_padron'] = 'EX'
+        elif padron.monotributo == 'S':
+            vals['imp_ganancias_padron'] = 'NC'
+        else:
+            _logger.info(
+                "We couldn't get impuesto a las ganancias from padron, you"
+                "must set it manually")
+
+        if padron.provincia:
+            # depending on the database, caba can have one of this codes
+            caba_codes = ['C', 'CABA', 'ABA']
+            # if not localidad then it should be CABA.
+            if not padron.localidad:
+                state = self.env['res.country.state'].search([
+                    ('code', 'in', caba_codes),
+                    ('country_id.code', '=', 'AR')], limit=1)
+            # If localidad cant be caba
+            else:
+                state = self.env['res.country.state'].search([
+                    ('name', 'ilike', padron.provincia),
+                    ('code', 'not in', caba_codes),
+                    ('country_id.code', '=', 'AR')], limit=1)
+            if state:
+                vals['state_id'] = state.id
+
+        if imp_iva == 'NI' and padron.monotributo == 'S':
+            vals['l10n_ar_afip_responsibility_type_id'] = self.env.ref(
+                'l10n_ar.res_RM').id
+        elif imp_iva == 'AC':
+            vals['l10n_ar_afip_responsibility_type_id'] = self.env.ref(
+                'l10n_ar.res_IVARI').id
+        elif imp_iva == 'EX':
+            vals['l10n_ar_afip_responsibility_type_id'] = self.env.ref(
+                'l10n_ar.res_IVAE').id
+        else:
+            _logger.info(
+                "We couldn't infer the AFIP responsability from padron, you"
+                "must set it manually.")
+
+        return vals

--- a/l10n_ar_afipws/wizard/__init__.py
+++ b/l10n_ar_afipws/wizard/__init__.py
@@ -2,4 +2,5 @@
 # For copyright and license notices, see __manifest__.py file in module root
 # directory
 ##############################################################################
+from . import res_partner_update_from_padron_wizard
 from . import upload_certificate_wizard

--- a/l10n_ar_afipws/wizard/res_partner_update_from_padron_wizard.py
+++ b/l10n_ar_afipws/wizard/res_partner_update_from_padron_wizard.py
@@ -7,6 +7,7 @@ _logger = logging.getLogger(__name__)
 
 class ResPartnerUpdateFromPadronField(models.TransientModel):
     _name = 'res.partner.update.from.padron.field'
+    _description = 'AFIP A5 Census Field'
 
     wizard_id = fields.Many2one(
         'res.partner.update.from.padron.wizard',
@@ -22,6 +23,7 @@ class ResPartnerUpdateFromPadronField(models.TransientModel):
 
 class ResPartnerUpdateFromPadronWizard(models.TransientModel):
     _name = 'res.partner.update.from.padron.wizard'
+    _description = 'AFIP A5 Census Wizard'
 
     @api.model
     def get_partners(self):

--- a/l10n_ar_afipws/wizard/res_partner_update_from_padron_wizard.py
+++ b/l10n_ar_afipws/wizard/res_partner_update_from_padron_wizard.py
@@ -1,0 +1,255 @@
+from odoo import models, api, fields, _
+from ast import literal_eval
+from odoo.exceptions import UserError
+import logging
+_logger = logging.getLogger(__name__)
+
+
+class ResPartnerUpdateFromPadronField(models.TransientModel):
+    _name = 'res.partner.update.from.padron.field'
+
+    wizard_id = fields.Many2one(
+        'res.partner.update.from.padron.wizard',
+        'Wizard',
+    )
+    field = fields.Char(
+    )
+    old_value = fields.Char(
+    )
+    new_value = fields.Char(
+    )
+
+
+class ResPartnerUpdateFromPadronWizard(models.TransientModel):
+    _name = 'res.partner.update.from.padron.wizard'
+
+    @api.model
+    def get_partners(self):
+        # TODO deberiamos buscar de otro manera estos partners
+        domain = [
+            ('vat', '!=', False),
+            ('l10n_latam_identification_type_id.l10n_ar_afip_code', '=', 80),
+        ]
+        active_ids = self._context.get('active_ids', [])
+        if active_ids:
+            domain.append(('id', 'in', active_ids))
+        return self.env['res.partner'].search(domain)
+
+    @api.model
+    def default_get(self, fields):
+        res = super(ResPartnerUpdateFromPadronWizard, self).default_get(
+            fields)
+        context = self._context
+        if (
+                context.get('active_model') == 'res.partner' and
+                context.get('active_ids')
+        ):
+            partners = self.get_partners()
+            if not partners:
+                raise UserError(_(
+                    'No se encontró ningún partner con CUIT para actualizar'))
+            elif len(partners) == 1:
+                res['state'] = 'selection'
+                res['partner_id'] = partners[0].id
+        return res
+
+    @api.model
+    def _get_domain(self):
+        fields_names = [
+            'name',
+            'estado_padron',
+            'street',
+            'city',
+            'zip',
+            'actividades_padron',
+            'impuestos_padron',
+            'imp_iva_padron',
+            'state_id',
+            'imp_ganancias_padron',
+            'monotributo_padron',
+            'actividad_monotributo_padron',
+            'empleador_padron',
+            'integrante_soc_padron',
+            'last_update_padron',
+            'afip_responsability_type_id',
+        ]
+        return [
+            ('model', '=', 'res.partner'),
+            ('name', 'in', fields_names),
+        ]
+
+    @api.model
+    def _get_default_title_case(self):
+        parameter = self.env['ir.config_parameter'].sudo().get_param(
+            'use_title_case_on_padron_afip')
+        if parameter == 'False' or parameter == '0':
+            return False
+        return True
+
+    @api.model
+    def get_fields(self):
+        return self.env['ir.model.fields'].search(self._get_domain())
+
+    state = fields.Selection([
+        ('option', 'Option'),
+        ('selection', 'Selection'),
+        ('finished', 'Finished')],
+        'State',
+        readonly=True,
+        required=True,
+        default='option',
+    )
+    field_ids = fields.One2many(
+        'res.partner.update.from.padron.field',
+        'wizard_id',
+        string='Fields',
+    )
+    partner_ids = fields.Many2many(
+        'res.partner',
+        'partner_update_from_padron_rel',
+        'update_id', 'partner_id',
+        string='Partners',
+        default=get_partners,
+    )
+    partner_id = fields.Many2one(
+        'res.partner',
+        string='Partner',
+        readonly=True,
+    )
+    update_constancia = fields.Boolean(
+        default=True,
+    )
+    title_case = fields.Boolean(
+        string='Title Case',
+        help='Converts retreived text fields to Title Case.',
+        default=_get_default_title_case,
+    )
+    field_to_update_ids = fields.Many2many(
+        'ir.model.fields',
+        'res_partner_update_fields',
+        'update_id', 'field_id',
+        string='Fields To Update',
+        help='Only this fields are going to be retrived and updated',
+        default=get_fields,
+        domain=_get_domain,
+        required=True,
+    )
+
+
+    @api.onchange('partner_id')
+    def change_partner(self):
+        self.ensure_one()
+        self.field_ids.unlink()
+        partner = self.partner_id
+        fields_names = self.field_to_update_ids.mapped('name')
+        if partner:
+            partner_vals = partner.get_data_from_padron_afip()
+            lines = []
+            for key, new_value in partner_vals.items():
+                old_value = partner[key]
+                if new_value == '':
+                    new_value = False
+                if self.title_case and key in ('name', 'city', 'street'):
+                    new_value = new_value and new_value.title()
+                if key in ('impuestos_padron', 'actividades_padron'):
+                    old_value = old_value.ids
+                elif key in ('state_id', 'afip_responsability_type_id'):
+                    old_value = old_value.id
+                if new_value and key in fields_names and \
+                        old_value != new_value:
+                    line_vals = {
+                        'wizard_id': self.id,
+                        'field': key,
+                        'old_value': old_value,
+                        'new_value': new_value or False,
+                    }
+                    lines.append((0, False, line_vals))
+            self.field_ids = lines
+
+
+    def _update(self):
+        self.ensure_one()
+        vals = {}
+        for field in self.field_ids:
+            if field.field in ('impuestos_padron', 'actividades_padron'):
+                vals[field.field] = [(6, False, literal_eval(field.new_value))]
+            else:
+                vals[field.field] = field.new_value
+        self.partner_id.write(vals)
+
+
+    def automatic_process_cb(self):
+        for partner in self.partner_ids:
+            self.partner_id = partner.id
+            self.change_partner()
+            self._update()
+
+        self.write({'state': 'finished'})
+        return {
+            'type': 'ir.actions.act_window',
+            'res_model': self._name,
+            'res_id': self.id,
+            'view_mode': 'form',
+            'target': 'new',
+        }
+
+
+    def update_selection(self):
+        self.ensure_one()
+        if not self.field_ids:
+            self.write({'state': 'finished'})
+            return {
+                'type': 'ir.actions.act_window',
+                'res_model': self._name,
+                'res_id': self.id,
+                'view_mode': 'form',
+                'target': 'new',
+            }
+        self._update()
+        return self.next_cb()
+
+
+    def next_cb(self):
+        """
+        """
+        self.ensure_one()
+        if self.partner_id:
+            self.write({'partner_ids': [(3, self.partner_id.id, False)]})
+        return self._next_screen()
+
+
+    def _next_screen(self):
+        self.ensure_one()
+        self.refresh()
+        values = {}
+        if self.partner_ids:
+            # in this case, we try to find the next record.
+            partner = self.partner_ids[0]
+            values.update({
+                'partner_id': partner.id,
+                'state': 'selection',
+            })
+        else:
+            values.update({
+                'state': 'finished',
+            })
+
+        self.write(values)
+        # because field is not changed, view is distroyed and reopen, on change
+        # is not called an we call it manually
+        self.change_partner()
+        return {
+            'type': 'ir.actions.act_window',
+            'res_model': self._name,
+            'res_id': self.id,
+            'view_mode': 'form',
+            'target': 'new',
+        }
+
+
+    def start_process_cb(self):
+        """
+        Start the process.
+        """
+        self.ensure_one()
+        return self._next_screen()

--- a/l10n_ar_afipws/wizard/res_partner_update_from_padron_wizard_view.xml
+++ b/l10n_ar_afipws/wizard/res_partner_update_from_padron_wizard_view.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+   <record model="ir.actions.act_window" id="action_base_partner_update_from_padron">
+        <field name="name">Update Partners From Padron AFIP</field>
+        <field name="res_model">res.partner.update.from.padron.wizard</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+
+    </record>
+
+    <menuitem id='menu_base_partner_update_from_padron'
+        action='action_base_partner_update_from_padron'
+        groups='base.group_system'
+        parent='contacts.res_partner_menu_config'/>
+
+    <record model='ir.ui.view' id='view_base_partner_update_from_padron_form'>
+        <field name='name'>res.partner.update.from.padron.wizard.form</field>
+        <field name='model'>res.partner.update.from.padron.wizard</field>
+        <field name='arch' type='xml'>
+            <form string='Update From Padron AFIP'>
+                <field name="state" invisible="1" />
+                <header>
+                    <button name='update_selection' string='Update Selection'
+                        class='oe_highlight'
+                        type='object'
+                        attrs="{'invisible': [('state', 'in', ('option', 'finished' ))]}"
+                        />
+                    <button name='next_cb' string='Skip these partner'
+                        type='object'  class='oe_link'
+                        attrs="{'invisible': [('state', '!=', 'selection')]}" />
+                    <button name='start_process_cb'
+                        string='Update with Manual Check'
+                        type='object'  class='oe_highlight'
+                        attrs="{'invisible': [('state', '!=', 'option')]}" />
+                    <button name='automatic_process_cb'
+                        string='Update Automatically'
+                        type='object' class='oe_highlight'
+                        confirm="Are you sure to execute the automatic update of your partners ?"
+                        attrs="{'invisible': [('state', '!=', 'option')]}" />
+                    <span class="or_cancel" attrs="{'invisible': [('state', '=', 'finished')]} ">or
+                        <button string="Cancel" class="oe_link oe_inline" special="cancel"/>
+                    </span>
+                    <span class="or_cancel" attrs="{'invisible': [('state', '!=', 'finished')]} ">
+                        <button string="Close" class="oe_link oe_inline" special="cancel"/>
+                    </span>
+                </header>
+                <sheet>
+                    <group attrs="{'invisible': [('state', '!=', 'finished')]}" col="1">
+                        <h2>There are no more partners to update for this request...</h2>
+
+                    </group>
+                    <p class="oe_grey" attrs="{'invisible': [('state', '!=', ('option'))]}">
+                        Only Partners with cuit are going to be updated.<br/>
+                        Select the list of fields you want to update.
+                    </p>
+                    <group attrs="{'invisible': [('state', 'not in', ('option',))]}">
+                        <field name="field_to_update_ids" widget="many2many_tags" options="{'no_create': True}" />
+                        <field name="update_constancia"/>
+                        <field name="title_case"/>
+                    </group>
+                    <group attrs="{'invisible': [('state', 'in', ('option', 'finished'))]}" col="1">
+                        <field name="partner_id" attrs="{'required': [('state', '=', 'selection')]}"/>
+                        <field name="field_ids" nolabel="1">
+                            <tree create="false">
+                                <field name="field"/>
+                                <field name="old_value"/>
+                                <field name="new_value"/>
+                            </tree>
+                        </field>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <act_window
+        id="action_partner_update"
+        res_model="res.partner.update.from.padron.wizard"
+        binding_model="res.partner"
+        target="new"
+        view_mode="form"
+        name="Automatic Update from Padron"/>
+
+    <record id="view_partner_form" model="ir.ui.view">
+        <field name="name">res.partner.form</field>
+        <field name="model">res.partner</field>
+        <field name="priority" eval="90"/>
+        <field name="inherit_id" ref="base.view_partner_form"/>
+        <field name="arch" type="xml">
+            <field name="vat" position="after">
+                <button name="%(action_partner_update)d" string="Update From AFIP" class="oe_link oe_inline" type="action" />
+            </field>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
- I reincorporate this feature as it's wide used and many people has asked for it.
- It's reincorporated as it was previous to deletion except that I've deleted commented code prior to A5 census usage (A4 census).
- Works fine, except that activities and taxes of partner are not written to partner because that information must be imported previously so the function can search the code and that function was deprecated in some migration (don't know exactly which), so we can add that later.
- As a future improvement we must work in translations and the import wizard.

