### PR TITLE
[FIX] l10n_ar_afipws_fe: renamed parameter in report controller

### DIFF
--- a/l10n_ar_afipws_fe/views/report_invoice.xml
+++ b/l10n_ar_afipws_fe/views/report_invoice.xml
@@ -9,7 +9,7 @@
             </div>
         </div>
         <div name="footer_left_column" position="inside">
-            <img t-if="o.afip_qr_code" t-att-src="'/report/barcode/?type=%s&amp;value=%s&amp;width=%s&amp;height=%s' % ('QR', o.afip_qr_code, 300,300)" alt="qr"  style="height:100px"/>
+            <img t-if="o.afip_qr_code" t-att-src="'/report/barcode/?barcode_type=%s&amp;value=%s&amp;width=%s&amp;height=%s' % ('QR', o.afip_qr_code, 300,300)" alt="qr"  style="height:100px"/>
         </div>
         <div name="pager" position="before">
             <div>


### PR DESCRIPTION
`type` is now `barcode_type`

See https://github.com/odoo/odoo/commit/ee324e8374536cebca4d7302210b07e8f33d3852