### PR TITLE
[REF] account_vat_ledger: reemplazo de 'states' por 'readonly' en presented_ledger para compatibilidad con Odoo 17

### DIFF
--- a/l10n_ar_reports/models/account_vat_ledger.py
+++ b/l10n_ar_reports/models/account_vat_ledger.py
@@ -58,7 +58,6 @@ class AccountVatLedger(models.Model):
     presented_ledger = fields.Binary(
         "Presented Ledger",
         readonly=True,
-        states={"draft": [("readonly", False)]},
     )
     presented_ledger_name = fields.Char()
     state = fields.Selection(

--- a/l10n_ar_reports/views/account_vat_report_views.xml
+++ b/l10n_ar_reports/views/account_vat_report_views.xml
@@ -36,7 +36,7 @@
                             <field name="date_from" readonly="state != 'draft'"/>
                             <field name="date_to" readonly="state != 'draft'"/>
                             <field name="presented_ledger_name" invisible="1"/>
-                            <field name="presented_ledger" filename="presented_ledger_name"/>
+                            <field name="presented_ledger" filename="presented_ledger_name" readonly="state != 'draft'"/>
                         </group>
                         <group>
                             <field name="first_page" readonly="state != 'draft'"/>


### PR DESCRIPTION
### Motivo del cambio

En Odoo 17, el atributo `states` en campos de modelo ha dejado de ser compatible.  
Para mantener la compatibilidad y evitar advertencias en los logs, se trasladó la lógica de visibilidad a la vista XML mediante el atributo `readonly`.

### Cambios realizados

- Se eliminó el atributo `states` del campo `presented_ledger` en el modelo `account_vat_ledger`.
- Se actualizó la vista correspondiente para aplicar la lógica mediante `readonly`.
