### PR TITLE
[FIX] l10n_ar_afipws_fe: remove redundant selection on related field

### DIFF
--- a/l10n_ar_afipws_fe/models/res_config_settings.py
+++ b/l10n_ar_afipws_fe/models/res_config_settings.py
@@ -19,7 +19,6 @@ class ResConfigSettings(models.TransientModel):
     )
 
     l10n_ar_payment_foreign_currency = fields.Selection(
-        [("S", "Yes"), ("N", "No"), ("account", "Account's Currency Dependant")],
         related="company_id.l10n_ar_payment_foreign_currency",
         readonly=False,
     )


### PR DESCRIPTION
## Summary

The `selection` argument on `res.config.settings.l10n_ar_payment_foreign_currency` is ignored by Odoo because the field is `related`. This produces a `WARNING` in the log on every registry load:

```
WARNING ... odoo.fields: res.config.settings.l10n_ar_payment_foreign_currency: selection attribute will be ignored as the field is related
```

The selection is inherited from `res.company.l10n_ar_payment_foreign_currency`, so the duplicated list on the `res.config.settings` declaration is unused and only adds noise.

## Changes

- `l10n_ar_afipws_fe/models/res_config_settings.py`: drop the duplicated `selection` list; keep only `related=` and `readonly=False`.

## Test plan

- [x] Module loads without the previous `WARNING`
- [x] Selection values on `res.config.settings` match those inherited from `res.company` (Yes / No / Account's Currency Dependant)