### PR TITLE
[MIG] Make AFIP WS modules installable on Odoo 19 CE.

### DIFF
--- a/l10n_ar_afipws/__manifest__.py
+++ b/l10n_ar_afipws/__manifest__.py
@@ -1,8 +1,8 @@
 {
     "name": "Modulo Base para los Web Services de AFIP",
-    "version": "18.0.1.0.0",
+    "version": "19.0.2.0.0",
     "category": "Localization/Argentina",
-    "author": "ADHOC SA, Moldeo Interactive,Odoo Community Association (OCA)",
+    "author": "ADHOC SA, Moldeo Interactive, Odoo Community Association (OCA), Be OnlyOne",
     "license": "AGPL-3",
     "summary": "",
     "depends": [
@@ -28,7 +28,7 @@
         "demo/parameter_demo.xml",
     ],
     "images": [],
-    "installable": False,
+    "installable": True,
     "auto_install": False,
     "application": False,
 }

--- a/l10n_ar_afipws/models/afipws_certificate.py
+++ b/l10n_ar_afipws/models/afipws_certificate.py
@@ -69,7 +69,7 @@ class AfipwsCertificate(models.Model):
         for rec in self:
             rec.request_filename = "request.csr"
             if rec.csr:
-                rec.request_file = base64.encodebytes(self.csr.encode("utf-8"))
+                rec.request_file = base64.encodebytes(rec.csr.encode("utf-8"))
             else:
                 rec.request_file = False
 
@@ -118,15 +118,15 @@ class AfipwsCertificate(models.Model):
             try:
                 certificate = crypto.load_certificate(crypto.FILETYPE_PEM, self.crt.encode("ascii"))
             except Exception as e:
-                if "Expecting: CERTIFICATE" in e[0]:
+                err = str(e)
+                if "Expecting: CERTIFICATE" in err:
                     raise UserError(
                         _(
                             "Wrong Certificate file format.\nBe sure you have "
                             "BEGIN CERTIFICATE string in your first line."
                         )
                     )
-                else:
-                    raise UserError(_("Unknown error.\nX509 return this message:\n %s") % (e[0]))
+                raise UserError(_("Unknown error.\nX509 return this message:\n %s") % err)
         else:
             certificate = None
         return certificate

--- a/l10n_ar_afipws/models/afipws_certificate_alias.py
+++ b/l10n_ar_afipws/models/afipws_certificate_alias.py
@@ -30,6 +30,11 @@ class AfipwsCertificateAlias(models.Model):
            SERIALNUMBER=CUIT 30714295698, CN=afip web services - adhoc s.a.
     """
 
+    @api.model
+    def _default_company_id(self):
+        """Return the company of the current environment."""
+        return self.env.company
+
     common_name = fields.Char(
         size=64,
         default="AFIP WS",
@@ -46,20 +51,23 @@ class AfipwsCertificateAlias(models.Model):
         "Company",
         required=True,
         readonly=True,
-        default=lambda self: self.env.company,
+        default=_default_company_id,
         auto_join=True,
         index=True,
+        ondelete="restrict",
     )
     country_id = fields.Many2one(
         "res.country",
         "Country",
         readonly=True,
         required=True,
+        ondelete="restrict",
     )
     state_id = fields.Many2one(
         "res.country.state",
         "State",
         readonly=True,
+        ondelete="set null",
     )
     city = fields.Char(
         readonly=True,
@@ -150,12 +158,13 @@ class AfipwsCertificateAlias(models.Model):
         return True
 
     def generate_key(self, key_length=2048):
-        """ """
-        # TODO reemplazar todo esto por las funciones nativas de pyafipws
+        """Generate an RSA private key in PEM format."""
+        # TODO replace this with native pyafipws helpers when available
         for rec in self:
             k = crypto.PKey()
             k.generate_key(crypto.TYPE_RSA, key_length)
-            rec.key = crypto.dump_privatekey(crypto.FILETYPE_PEM, k)
+            pem = crypto.dump_privatekey(crypto.FILETYPE_PEM, k)
+            rec.key = pem.decode("ascii") if isinstance(pem, bytes) else pem
 
     def action_to_draft(self):
         self.write({"state": "draft"})
@@ -167,29 +176,28 @@ class AfipwsCertificateAlias(models.Model):
         return True
 
     def action_create_certificate_request(self):
-        """
-        TODO agregar descripcion y ver si usamos pyafipsw para generar esto
-        """
+        """Create a CSR for each alias using OpenSSL."""
         for record in self:
             req = crypto.X509Req()
-            req.get_subject().C = self.country_id.code.encode("ascii", "ignore")
-            if self.state_id:
-                req.get_subject().ST = self.state_id.name.encode("ascii", "ignore")
-            req.get_subject().L = self.city.encode("ascii", "ignore")
-            req.get_subject().O = self.company_id.name.encode("ascii", "ignore")
-            req.get_subject().OU = self.department.encode("ascii", "ignore")
-            req.get_subject().CN = self.common_name.encode("ascii", "ignore")
-            req.get_subject().serialNumber = "CUIT %s" % self.cuit.encode("ascii", "ignore")
-            k = crypto.load_privatekey(crypto.FILETYPE_PEM, self.key)
-            self.key = crypto.dump_privatekey(crypto.FILETYPE_PEM, k)
+            req.get_subject().C = (record.country_id.code or "").encode("ascii", "ignore").decode("ascii")
+            if record.state_id:
+                req.get_subject().ST = (record.state_id.name or "").encode("ascii", "ignore").decode("ascii")
+            req.get_subject().L = (record.city or "").encode("ascii", "ignore").decode("ascii")
+            req.get_subject().O = (record.company_id.name or "").encode("ascii", "ignore").decode("ascii")
+            req.get_subject().OU = (record.department or "").encode("ascii", "ignore").decode("ascii")
+            req.get_subject().CN = (record.common_name or "").encode("ascii", "ignore").decode("ascii")
+            req.get_subject().serialNumber = "CUIT %s" % (record.cuit or "")
+            k = crypto.load_privatekey(crypto.FILETYPE_PEM, record.key)
+            pem_key = crypto.dump_privatekey(crypto.FILETYPE_PEM, k)
+            record.key = pem_key.decode("ascii") if isinstance(pem_key, bytes) else pem_key
             req.set_pubkey(k)
             req.sign(k, "sha256")
             csr = crypto.dump_certificate_request(crypto.FILETYPE_PEM, req)
             vals = {
-                "csr": csr,
+                "csr": csr.decode("ascii") if isinstance(csr, bytes) else csr,
                 "alias_id": record.id,
             }
-            self.certificate_ids.create(vals)
+            record.certificate_ids.create(vals)
         return True
 
     @api.constrains("common_name")

--- a/l10n_ar_afipws/models/afipws_connection.py
+++ b/l10n_ar_afipws/models/afipws_connection.py
@@ -22,6 +22,7 @@ class AfipwsConnection(models.Model):
         required=True,
         index=True,
         auto_join=True,
+        ondelete="restrict",
     )
     uniqueid = fields.Char(
         "Unique ID",
@@ -151,10 +152,10 @@ class AfipwsConnection(models.Model):
                 msg = _("It seems like AFIP service is not available.\nPlease try again later or try manually")
                 raise RedirectWarning(msg, action.id, _("Go and find data manually"))
             raise UserError(
-                "There was a connection problem to AFIP. Contact your Odoo Provider. Error\n\n%s" % repr(error)
+                _("There was a connection problem to AFIP. Contact your Odoo Provider. Error\n\n%s") % repr(error)
             )
 
-        cuit = self.company_id.partner_id.ensure_vat()
+        cuit = self._get_afip_ws_cuit()
         ws.Cuit = cuit
         ws.Token = self.token
         ws.Sign = self.sign
@@ -164,6 +165,36 @@ class AfipwsConnection(models.Model):
 
         _logger.info('Connection getted with url "%s", cuit "%s"' % (wsdl, ws.Cuit))
         return ws
+
+    def _get_afip_ws_cuit(self):
+        """CUIT sent in WSFE Auth must match the certificate used for WSAA.
+
+        Demo companies keep a dummy partner VAT (e.g. 20222222223) even after a
+        real production certificate is loaded on the alias.
+        """
+        self.ensure_one()
+        alias = self.env["afipws.certificate_alias"].search(
+            [
+                ("company_id", "=", self.company_id.id),
+                ("type", "=", self.type),
+                ("state", "=", "confirmed"),
+            ],
+            limit=1,
+        )
+        raw_cuit = ""
+        if alias:
+            raw_cuit = alias.cuit or alias.company_cuit or ""
+        cuit = "".join(ch for ch in raw_cuit if ch.isdigit())
+        if not cuit:
+            cuit = self.company_id.partner_id.ensure_vat()
+        partner_cuit = self.company_id.partner_id.l10n_ar_vat or ""
+        if partner_cuit and cuit and partner_cuit != cuit:
+            _logger.warning(
+                "Using certificate CUIT %s for AFIP WS (company partner VAT is %s)",
+                cuit,
+                partner_cuit,
+            )
+        return cuit
 
     @api.model
     def _get_ws(self, afip_ws):

--- a/l10n_ar_afipws/models/res_company.py
+++ b/l10n_ar_afipws/models/res_company.py
@@ -5,7 +5,6 @@
 import hashlib
 import logging
 import os
-import sys
 import time
 import traceback
 
@@ -237,14 +236,13 @@ class ResCompany(models.Model):
             expirationTime = wsaa.ObtenerTagXml("expirationTime")
             generationTime = wsaa.ObtenerTagXml("generationTime")
             uniqueId = wsaa.ObtenerTagXml("uniqueId")
-        except Exception:
+        except Exception as err:
             token = sign = None
             if wsaa.Excepcion:
                 # get the exception already parsed by the helper
                 err_msg = wsaa.Excepcion
             else:
-                # avoid encoding problem when reporting exceptions to the user:
-                err_msg = traceback.format_exception_only(sys.exc_type, sys.exc_value)[0]
+                err_msg = traceback.format_exception_only(type(err), err)[0]
             raise UserError(_("Could not connect. This is the what we received: %s") % (err_msg))
         return {
             "uniqueid": uniqueId,

--- a/l10n_ar_afipws/models/res_partner.py
+++ b/l10n_ar_afipws/models/res_partner.py
@@ -95,7 +95,7 @@ class ResPartner(models.Model):
         # GET COMPANY
         # if there is certificate for user company, use that one, if not
         # use the company for the first certificate found
-        company = self.env.user.company_id
+        company = self.env.company
         env_type = company._get_environment_type()
         try:
             certificate = company.get_key_and_certificate(company._get_environment_type())
@@ -131,7 +131,7 @@ class ResPartner(models.Model):
     def l10n_ar_afipws_fe_min_ammount(self):
         for record in self:
             if record.l10n_ar_vat:
-                ws = self.env.user.company_id.get_connection("wsfecred").connect()
+                ws = self.env.company.get_connection("wsfecred").connect()
                 res = ws.ConsultarMontoObligadoRecepcion(record.l10n_ar_vat)
                 record.mipyme_required = True if ws.Resultado == "S" else False
                 record.mipyme_from_amount = float(res)

--- a/l10n_ar_afipws/views/res_partner.xml
+++ b/l10n_ar_afipws/views/res_partner.xml
@@ -5,7 +5,7 @@
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="account.view_partner_property_form"/>
         <field name="arch" type="xml">
-            <group name="accounting_entries" position="after">
+            <group name="general" position="after">
                 <group name="miPyme" string="Mi pyme">
                     <field name="mipyme_required"/>
                     <field name="mipyme_from_amount" invisible="not mipyme_required"/>

--- a/l10n_ar_afipws/wizard/res_partner_update_from_padron_wizard.py
+++ b/l10n_ar_afipws/wizard/res_partner_update_from_padron_wizard.py
@@ -14,6 +14,7 @@ class ResPartnerUpdateFromPadronField(models.TransientModel):
     wizard_id = fields.Many2one(
         "res.partner.update.from.padron.wizard",
         "Wizard",
+        ondelete="cascade",
     )
     field = fields.Char("name")
     old_value = fields.Char("old Value")
@@ -98,6 +99,7 @@ class ResPartnerUpdateFromPadronWizard(models.TransientModel):
         "res.partner",
         string="Partner",
         readonly=True,
+        ondelete="cascade",
     )
     update_constancia = fields.Boolean(
         default=True,

--- a/l10n_ar_afipws_fe/__manifest__.py
+++ b/l10n_ar_afipws_fe/__manifest__.py
@@ -1,8 +1,8 @@
 {
     "name": "Factura Electrónica Argentina",
-    "version": "18.0.2.0.0",
+    "version": "19.0.3.1.0",
     "category": "Localization/Argentina",
-    "author": "ADHOC SA, Moldeo Interactive,Odoo Community Association (OCA)",
+    "author": "ADHOC SA, Moldeo Interactive, Odoo Community Association (OCA), Be OnlyOne",
     "license": "AGPL-3",
     "summary": "",
     "depends": [
@@ -22,7 +22,7 @@
     ],
     "demo": [],
     "images": [],
-    "installable": False,
+    "installable": True,
     "auto_install": False,
     "application": False,
 }

--- a/l10n_ar_afipws_fe/models/account_journal.py
+++ b/l10n_ar_afipws_fe/models/account_journal.py
@@ -15,6 +15,7 @@ class AccountJournal(models.Model):
 
     afip_ws = fields.Selection(selection="_get_afip_ws", compute="_compute_afip_ws", string="AFIP WS")
 
+    @api.model
     def _get_afip_ws(self):
         return [
             ("wsfe", _("Domestic market -without detail- RG2485 (WSFEv1)")),

--- a/l10n_ar_afipws_fe/models/account_journal_ws.py
+++ b/l10n_ar_afipws_fe/models/account_journal_ws.py
@@ -20,6 +20,34 @@ _logger = logging.getLogger(__name__)
 class AccountJournalWs(models.Model):
     _inherit = "account.journal"
 
+    def _afip_ws_error_message(self, ws, result=None):
+        """Return AFIP error text from a SOAP result dict and pyafipws attributes."""
+        msgs = []
+        for error in (result or {}).get("Errors") or []:
+            err = error.get("Err") or error
+            code = err.get("Code")
+            msg = err.get("Msg")
+            if code or msg:
+                msgs.append("%s: %s" % (code, msg))
+        for attr in ("ErrMsg", "Excepcion", "Obs"):
+            value = getattr(ws, attr, None)
+            if value and str(value) not in msgs:
+                msgs.append(str(value))
+        return "\n".join(filter(None, msgs))
+
+    def _afip_ws_missing_result_error(self, ws, result=None):
+        """Explain a missing ResultGet, including environment mismatch hints."""
+        details = self._afip_ws_error_message(ws, result)
+        hint = _(
+            "AFIP did not return the expected data. Dummy Test only checks that "
+            "WSFE servers are up. Use a homologation certificate with environment "
+            "Homologation, or a production certificate with environment Production. "
+            "The CUIT must have WSFE and the point of sale enabled in that same environment."
+        )
+        if details:
+            return "%s\n\n%s" % (details, hint)
+        return hint
+
     def get_pyafipws_post_invoice_numbers(self):
         for journal_id in self:
             msg = []
@@ -81,10 +109,14 @@ class AccountJournalWs(models.Model):
             ret = getattr(self, "%s_pyafipws_point_of_sales" % afip_ws)(ws)
         else:
             raise UserError(_("Get point of sale for ws %s is not implemented yet") % (afip_ws))
-        msg = _(" %s %s") % (
-            ". ".join(ret),
-            " - ".join([ws.Excepcion, ws.ErrMsg, ws.Obs]),
-        )
+        if not ret:
+            notification_type = "warning"
+            msg = self._afip_ws_missing_result_error(ws)
+        else:
+            msg = _(" %s %s") % (
+                ". ".join(ret),
+                " - ".join([ws.Excepcion, ws.ErrMsg, ws.Obs]),
+            )
         title = _("Enabled Point Of Sales on AFIP\n")
 
         notification = {
@@ -172,7 +204,21 @@ class AccountJournalWs(models.Model):
         return ws.GetParamTipoCbte(sep=",")
 
     def wsfe_pyafipws_cuit_document_classes(self, ws):
-        return ws.ParamGetTiposCbte(sep=",")
+        try:
+            ret = ws.ParamGetTiposCbte(sep=",")
+        except (KeyError, TypeError):
+            soap = {}
+            try:
+                soap = ws.client.FEParamGetTiposCbte(
+                    Auth={"Token": ws.Token, "Sign": ws.Sign, "Cuit": ws.Cuit},
+                )
+            except Exception:
+                _logger.warning("Could not re-read FEParamGetTiposCbte response", exc_info=True)
+            res = soap.get("FEParamGetTiposCbteResult") or {}
+            raise UserError(self._afip_ws_missing_result_error(ws, res)) from None
+        if not ret:
+            raise UserError(self._afip_ws_missing_result_error(ws))
+        return ret
 
     def wsbfe_pyafipws_cuit_document_classes(self, ws):
         return ws.GetParamTipoCbte()

--- a/l10n_ar_afipws_fe/models/account_move.py
+++ b/l10n_ar_afipws_fe/models/account_move.py
@@ -5,7 +5,6 @@
 import base64
 import json
 import logging
-import sys
 import traceback
 from datetime import datetime
 
@@ -14,8 +13,6 @@ from odoo.exceptions import UserError
 from odoo.tools import float_repr
 
 from ..afip_utils import get_invoice_number_from_response
-
-base64.encodestring = base64.encodebytes
 
 _logger = logging.getLogger(__name__)
 
@@ -191,7 +188,7 @@ class AccountMove(models.Model):
                         rec.commercial_partner_id.l10n_latam_identification_type_id.l10n_ar_afip_code
                     )
                     qr_dict["nroDocRec"] = int(rec.commercial_partner_id.vat.replace("-", "").replace(".", ""))
-                qr_data = base64.encodestring(json.dumps(qr_dict, indent=None).encode("ascii")).decode("ascii")
+                qr_data = base64.encodebytes(json.dumps(qr_dict, indent=None).encode("ascii")).decode("ascii")
                 qr_data = str(qr_data).replace("\n", "")
                 rec.afip_qr_code = "https://www.afip.gob.ar/fe/qr/?p=%s" % qr_data
             else:
@@ -239,6 +236,7 @@ class AccountMove(models.Model):
                     "Factura validada solo localmente por estar en ambiente "
                     "de homologación sin claves de homologación"
                 )
+                # sudo: local dummy CAE when homologation certs are missing.
                 inv.sudo().write(
                     {
                         "afip_auth_mode": "CAE",
@@ -278,14 +276,10 @@ class AccountMove(models.Model):
                 # Pido autorizacion
                 inv.pyafipws_request_autorization(ws, afip_ws)
             except Exception as e:
-                msg = e
-            except Exception:
-                if ws.Excepcion:
-                    # get the exception already parsed by the helper
+                if getattr(ws, "Excepcion", None):
                     msg = ws.Excepcion
                 else:
-                    # avoid encoding problem when raising error
-                    msg = traceback.format_exception_only(sys.exc_type, sys.exc_value)[0]
+                    msg = traceback.format_exception_only(type(e), e)[0]
             if msg:
                 _logger.error(
                     _("AFIP Validation Error. %s") % msg
@@ -303,7 +297,10 @@ class AccountMove(models.Model):
                     "afip_xml_request": ws.XmlRequest or "",
                     "afip_xml_response": ws.XmlResponse or "",
                 }
+                # sudo: persist AFIP rejection XML even if the user cannot write
+                # technical fields; the invoice stays draft.
                 inv.sudo().write(vals)
+                # Commit so a later rollback cannot drop the AFIP response.
                 inv._cr.commit()
                 continue
 
@@ -323,10 +320,9 @@ class AccountMove(models.Model):
                 "afip_xml_response": ws.XmlResponse,
             }
 
+            # sudo: store CAE returned by AFIP; this cannot be rolled back.
             inv.sudo().write(vals)
             inv._cr.commit()
-            # si obtuvimos el cae hacemos el commit porque estoya no se puede
-            # volver atras
             a_invoices += inv
         return (a_invoices, r_invoices)
 

--- a/l10n_ar_afipws_fe/views/account_journal_view.xml
+++ b/l10n_ar_afipws_fe/views/account_journal_view.xml
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="view_account_journal_form" model="ir.ui.view">
-        <field name="name">account.journal.form</field>
+        <field name="name">account.journal.form.inherit.l10n_ar_afipws_fe</field>
         <field name="model">account.journal</field>
-        <field name="inherit_id" ref="account.view_account_journal_form"/>
+        <field name="inherit_id" ref="l10n_ar.view_account_journal_form"/>
         <field name="arch" type="xml">
-            <form>
-                <field name="afip_ws" invisible="1"/>
-            </form>
-            <sheet position="before">
+            <xpath expr="//sheet" position="before">
                 <header>
-                    <button name="action_get_connection" string="Get Connection" help="Get Connection For this webservice and create it if no valid" type="object" invisible="not afip_ws"/>
-                    <button name="test_pyafipws_dummy" string="Dummy Test" help="Dummy test to check connection to selected webservice" type="object" invisible="not afip_ws"/>
-                    <button name="test_pyafipws_point_of_sales" string="Get Points Of Sale" help="Get Enable Point of Sales for this webservice" type="object" invisible="not afip_ws"/>
-                    <button name="get_pyafipws_cuit_document_classes" string="Get Document Types" help="Get valid document types for this webservice" type="object" invisible="not afip_ws"/>
-                    <button name="get_pyafipws_zonas" string="Get Zones" help="Get zones for this webservice" type="object" invisible="afip_ws != 'wsbfe'"/>
-                    <button name="get_pyafipws_NCM" string="Get NCM" help="Obtener códigos del Nomenclador Común del Mercosur" type="object" invisible="afip_ws != 'wsbfe'"/>
-                    <button name="get_pyafipws_post_invoice_numbers" string="Get next Inv" help="Obtener numeros de factura" type="object" invisible="not afip_ws"/>
+                    <button name="action_get_connection" string="Get Connection" help="Get Connection For this webservice and create it if no valid" type="object" invisible="not l10n_ar_is_pos"/>
+                    <button name="test_pyafipws_dummy" string="Dummy Test" help="Dummy test to check connection to selected webservice" type="object" invisible="not l10n_ar_is_pos"/>
+                    <button name="test_pyafipws_point_of_sales" string="Get Points Of Sale" help="Get Enable Point of Sales for this webservice" type="object" invisible="not l10n_ar_is_pos"/>
+                    <button name="get_pyafipws_cuit_document_classes" string="Get Document Types" help="Get valid document types for this webservice" type="object" invisible="not l10n_ar_is_pos"/>
+                    <button name="get_pyafipws_zonas" string="Get Zones" help="Get zones for this webservice" type="object" invisible="not l10n_ar_is_pos or l10n_ar_afip_pos_system != 'BFEWS'"/>
+                    <button name="get_pyafipws_NCM" string="Get NCM" help="Obtener códigos del Nomenclador Común del Mercosur" type="object" invisible="not l10n_ar_is_pos or l10n_ar_afip_pos_system != 'BFEWS'"/>
+                    <button name="get_pyafipws_post_invoice_numbers" string="Get next Inv" help="Obtener numeros de factura" type="object" invisible="not l10n_ar_is_pos"/>
                 </header>
-            </sheet>
+            </xpath>
+            <xpath expr="//field[@name='l10n_ar_afip_pos_system']" position="after">
+                <field name="afip_ws" readonly="1" invisible="not l10n_ar_is_pos"/>
+            </xpath>
         </field>
     </record>
 </odoo>

--- a/l10n_ar_afipws_fe/views/account_move_views.xml
+++ b/l10n_ar_afipws_fe/views/account_move_views.xml
@@ -4,43 +4,43 @@
     <record id="view_move_form" model="ir.ui.view">
         <field name="model">account.move</field>
         <field name="name">account.move.afip.form</field>
-         <field name="inherit_id" ref="l10n_ar.view_move_form"/>
+        <field name="inherit_id" ref="l10n_ar.view_move_form"/>
         <field name="arch" type="xml">
-            <!-- we change button labels for better usability -->
-            <button name="action_post" position="attributes">
-                <attribute name="invisible">state != 'draft' or validation_type</attribute>
-                <attribute name="states"/>
-            </button>
-            <button name="action_post" position="after">
+            <xpath expr="//header" position="inside">
+                <field name="validation_type" invisible="1"/>
+            </xpath>
+            <!-- Target the invoice Confirm button, not the journal-entry Post button. -->
+            <xpath expr="//header/button[@name='action_post'][contains(@invisible, 'display_inactive_currency_warning')]" position="attributes">
+                <attribute name="invisible">hide_post_button or move_type == 'entry' or display_inactive_currency_warning or validation_type</attribute>
+            </xpath>
+            <xpath expr="//header/button[@name='action_post'][contains(@invisible, 'display_inactive_currency_warning')]" position="after">
                 <button name="action_post" type="object" invisible="state != 'draft' or validation_type != 'production'" string="Validar en AFIP" class="oe_highlight" groups="account.group_account_invoice"/>
                 <button name="action_post" type="object" invisible="state != 'draft' or validation_type != 'homologation'" string="Validar en HOMOLOGACION" class="oe_highlight" groups="account.group_account_invoice"/>
-                <button name="get_pyafipws_currency_rate" type="object" invisible="state != 'draft' or not validation_type != '' or not invoice_date" string="Check rate" groups="account.group_account_invoice"/>
-
-            </button>
+                <button name="get_pyafipws_currency_rate" type="object" invisible="state != 'draft' or not validation_type or not invoice_date" string="Check rate" groups="account.group_account_invoice"/>
+            </xpath>
             <field name="l10n_ar_afip_concept" position="after">
                 <field name="afip_fce_es_anulacion"/>
                 <label for="afip_auth_code" string="AFIP associated period" invisible="move_type != 'out_refund'"/>
-                <div class="oe_inline"  invisible="move_type != 'out_refund'">
+                <div class="oe_inline" invisible="move_type != 'out_refund'">
                         <field name="afip_associated_period_from" class="oe_inline" placeholder="Date From"/> -
                         <field name="afip_associated_period_to" class="oe_inline" placeholder="Date to"/>
                 </div>
-                <field name='l10n_ar_payment_foreign_currency'/>
+                <field name="l10n_ar_payment_foreign_currency"/>
 
             </field>
             <notebook>
                 <page string="AFIP" name="afip" invisible="move_type not in ['out_invoice', 'out_refund']">
                     <group>
-                        <field name='validation_type' invisible="1"/>
                         <label for="afip_auth_code" string="AFIP authorization"/>
                         <div class="oe_inline">
                             <field name="afip_auth_mode" class="oe_inline" readonly="state != 'draft'"/>
                             <field name="afip_auth_code" class="oe_inline" readonly="state != 'draft'" required="afip_auth_mode" placeholder="Code"/> -
                         </div>
-                        <field name='afip_auth_code_due' readonly="state != 'draft'"/>
-                        <field name='afip_result' readonly="state != 'draft'"/>
-                        <field name='afip_message'/>
-                        <field name='afip_xml_request' widget="ace" groups="base.group_no_one"/>
-                        <field name='afip_xml_response'  widget="ace" groups="base.group_no_one"/>
+                        <field name="afip_auth_code_due" readonly="state != 'draft'"/>
+                        <field name="afip_result" readonly="state != 'draft'"/>
+                        <field name="afip_message"/>
+                        <field name="afip_xml_request" widget="ace" groups="base.group_no_one"/>
+                        <field name="afip_xml_response" widget="ace" groups="base.group_no_one"/>
                     </group>
                 </page>
             </notebook>

--- a/l10n_ar_afipws_fe/wizard/account_validate_account_move.py
+++ b/l10n_ar_afipws_fe/wizard/account_validate_account_move.py
@@ -19,7 +19,7 @@ class ValidateAccountMove(models.TransientModel):
             moves = self.env["account.move"].search(domain).filtered("line_ids")
             if not moves:
                 raise UserError(_("There are no journal items in the draft state to post."))
-            moves.asynchronous_post = True
+            moves.write({"asynchronous_post": True})
             return {"type": "ir.actions.act_window_close"}
 
         else:

--- a/l10n_ar_pos_afipws_fe/__manifest__.py
+++ b/l10n_ar_pos_afipws_fe/__manifest__.py
@@ -1,8 +1,8 @@
 {
     "name": "Punto de venta Factura Electrónica Argentina",
-    "version": "18.0.1.0.0",
+    "version": "19.0.1.0.0",
     "category": "Localization/Argentina",
-    "author": "ADHOC SA, Filoquin",
+    "author": "ADHOC SA, Filoquin, Be OnlyOne",
     "license": "AGPL-3",
     "summary": "",
     "depends": [
@@ -14,7 +14,7 @@
     "demo": [],
     "assets": {},
     "images": [],
-    "installable": False,
+    "installable": True,
     "auto_install": False,
     "application": False,
 }

--- a/l10n_ar_reports/__manifest__.py
+++ b/l10n_ar_reports/__manifest__.py
@@ -1,9 +1,9 @@
 {
     "name": "Argentinian Reports (CE)",
-    "version": "16.0.1.0.0",
+    "version": "19.0.1.0.0",
     "category": "Localization/Argentina",
     "sequence": 14,
-    "author": "ADHOC SA,Moldeo Interactive,Odoo Community Association (OCA)",
+    "author": "ADHOC SA, Moldeo Interactive, Odoo Community Association (OCA), Be OnlyOne",
     "license": "AGPL-3",
     "summary": "",
     "depends": [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,10 @@
 pyOpenSSL
-M2Crypto
+cryptography
 httplib2>=0.7
-pysimplesoap~=1.8.22
-# fpdf>=1.7.2
-# dbf>=0.88.019
-# Pillow>=2.0.0
-# git+https://github.com/OCA/openupgradelib/@master
-# git+https://github.com/reingart/pyafipws@py3k
-# git+https://github.com/ingadhoc/pyafipws@py3k
-git+https://github.com/filoquin/pyafipws.git@py3k
+# Python 3.12 (Ubuntu 24.04 / Odoo 19): use Adhoc pyafipws odoo18 branch
+# (cryptography + pysimplesoap py311). Do not pin M2Crypto by default.
+#
+# Fallback if WSAA/WSFE cannot authenticate:
+#   git+https://github.com/filoquin/pyafipws.git@py3k
+# that pin may need M2Crypto (apt: swig libssl-dev) — keep the traceback.
+git+https://github.com/ingadhoc/pyafipws.git@odoo18


### PR DESCRIPTION
## Summary
- Make `l10n_ar_afipws`, `l10n_ar_afipws_fe` and `l10n_ar_pos_afipws_fe` installable on Odoo 19 Community, keeping pyafipws (WSAA / WSFE).
- Adapt journal/invoice views to Odoo 19 (`l10n_ar_is_pos`, header actions, Confirm button xpath).
- Authenticate WSFE with the CUIT from the AFIP certificate alias (not the demo company VAT).
- Surface AFIP SOAP errors instead of crashing on missing `ResultGet`.
- Pin `ingadhoc/pyafipws@odoo18` + `cryptography` in `requirements.txt`.
- `l10n_ar_reports` stays `installable: False` (needs `report_xlsx`).

Be OnlyOne is listed as co-author on the migrated modules.

## Test plan
- [x] Install `l10n_ar` + `l10n_ar_afipws` + `l10n_ar_afipws_fe` on a clean Odoo 19 CE database.
- [x] Load a **production** AFIP certificate and set WS environment to Production.
- [x] Journal actions: Get Connection, Dummy Test, Get Points Of Sale, Get Document Types, Get next Inv.
- [x] Electronic invoicing works: request CAE and post an invoice against AFIP production.